### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "dart"
+run = "todo"

--- a/README.md
+++ b/README.md
@@ -49,3 +49,4 @@ Thank you in advanced 👍
 
 There are other example Apps made with flutter, see more on [Interestinate](https://interestinate.com).
 
+[![Run on Repl.it](https://repl.it/badge/github/inspireui/Flutter-Todolist)](https://repl.it/github/inspireui/Flutter-Todolist)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@AdnanMuratovic/Flutter-Todolist).